### PR TITLE
Enhance-cert-manager issuer

### DIFF
--- a/environment-template/infrastructure/README.md
+++ b/environment-template/infrastructure/README.md
@@ -27,6 +27,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_cert_manager_issuer_project_id"></a> [cert\_manager\_issuer\_project\_id](#output\_cert\_manager\_issuer\_project\_id) | Project ID in which the Cloud DNS zone to manage the DNS entries is located. |
 | <a name="output_cert_manager_sa_account_id"></a> [cert\_manager\_sa\_account\_id](#output\_cert\_manager\_sa\_account\_id) | Account id of the cert-manager Service Account |
 | <a name="output_cert_manager_sa_key_file"></a> [cert\_manager\_sa\_key\_file](#output\_cert\_manager\_sa\_key\_file) | Service Account Key File for cert-manager Service Account |
 | <a name="output_cloud_endpoints_key_file"></a> [cloud\_endpoints\_key\_file](#output\_cloud\_endpoints\_key\_file) | Service Account Key File for Cloud Endpoints Service Account |

--- a/environment-template/infrastructure/outputs.tf
+++ b/environment-template/infrastructure/outputs.tf
@@ -85,3 +85,8 @@ output "cert_manager_sa_key_file" {
   description = "Service Account Key File for cert-manager Service Account"
   sensitive   = true
 }
+
+output "cert_manager_issuer_project_id" {
+  value        = module.infrastructure.cert_manager_issuer_project_id
+  description = "Project ID in which the Cloud DNS zone to manage the DNS entries is located."
+}

--- a/environment-template/software/main.tf
+++ b/environment-template/software/main.tf
@@ -15,6 +15,7 @@ module "software" {
   cloud_endpoints_key_file            = data.terraform_remote_state.infrastructure.outputs.cloud_endpoints_key_file
   cert_manager_sa_account_id          = try(data.terraform_remote_state.infrastructure.outputs.cert_manager_sa_account_id[0], "")
   cert_manager_sa_key_file            = try(data.terraform_remote_state.infrastructure.outputs.cert_manager_sa_key_file[0], "")
+  cert_manager_issuer_project_id      = try(data.terraform_remote_state.infrastructure.outputs.cert_manager_issuer_project_id[0], "")
   hono_tls_key_from_storage           = try(data.terraform_remote_state.software.outputs.hono_tls_key_in_storage, null)
   hono_tls_crt_from_storage           = try(data.terraform_remote_state.software.outputs.hono_tls_crt_in_storage, null)
   hono_tls_key                        = try(file("${path.module}/hono_tls.key"), null)


### PR DESCRIPTION
Added cert_manager_issuer_project_id variable to make it possible to use the cert-manager even if the domain is managed in a different Google project than the one Hono is deployed to.